### PR TITLE
Use dependency release date in time to merge calculation

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+source "https://rubygems.org"
+
+gem "octokit", "~> 6.1"
+gem "slop"
+
+group :test do
+  gem "rake"
+  gem "rspec"
+  gem "webmock"
+end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,54 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    addressable (2.8.1)
+      public_suffix (>= 2.0.2, < 6.0)
+    crack (0.4.5)
+      rexml
+    diff-lcs (1.5.0)
+    faraday (2.7.4)
+      faraday-net_http (>= 2.0, < 3.1)
+      ruby2_keywords (>= 0.0.4)
+    faraday-net_http (3.0.2)
+    hashdiff (1.0.1)
+    octokit (6.1.0)
+      faraday (>= 1, < 3)
+      sawyer (~> 0.9)
+    public_suffix (5.0.1)
+    rake (13.0.6)
+    rexml (3.2.5)
+    rspec (3.12.0)
+      rspec-core (~> 3.12.0)
+      rspec-expectations (~> 3.12.0)
+      rspec-mocks (~> 3.12.0)
+    rspec-core (3.12.1)
+      rspec-support (~> 3.12.0)
+    rspec-expectations (3.12.2)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.12.0)
+    rspec-mocks (3.12.3)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.12.0)
+    rspec-support (3.12.0)
+    ruby2_keywords (0.0.5)
+    sawyer (0.9.2)
+      addressable (>= 2.3.5)
+      faraday (>= 0.17.3, < 3)
+    slop (4.10.1)
+    webmock (3.18.1)
+      addressable (>= 2.8.0)
+      crack (>= 0.3.2)
+      hashdiff (>= 0.4.0, < 2.0.0)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  octokit (~> 6.1)
+  rake
+  rspec
+  slop
+  webmock
+
+BUNDLED WITH
+   2.1.4

--- a/README.md
+++ b/README.md
@@ -13,11 +13,17 @@ this repo includes:
   version bumps.
 
 - Statistics on "time to merge" Dependabot PRs, showing how many days
-  have passed between Dependabot PRs being opened and merged. GitHub
-  Search API has a limit of 1000 results, and that's before filtering
-  out the non govuk repos, so we can only get statistics for the last
-  few weeks. GitHub's Search API applies strict secondary rate-limiting,
-  hence the need to stagger requests, which makes this a bit slow to run.
+  have passed between Dependabot PRs being opened and merged. We are
+  retrieving maximum 300 PRs per repository, so we won't have accurate
+  statistics for the PRs opened a few months in the past. The script
+  takes around 15 minutes to run.
+
+  ```
+  ./dependabot_time_to_merge --from 2023-03-27 --to 2023-03-28 --outdated-limit 30
+  ```
+
+  `--outdated-limit` option is used for displaying which dependencies were outdated
+  for more than X number of days (default value is 20)
 
 They all require `GITHUB_TOKEN` as an environment variable, with at
 least `repo` scope.

--- a/dependabot_time_to_merge
+++ b/dependabot_time_to_merge
@@ -1,0 +1,26 @@
+#!/usr/bin/env ruby
+
+require "slop"
+require "./dependabot_time_to_merge.rb"
+
+def get_options
+  options = Slop::Options.new do |o|
+    o.on "-h", "--help", "print this usage information" do
+      puts o
+      exit
+    end
+    o.string "--from", "(required)", required: true
+    o.string "--to", "(required)", required: true
+    o.string "--outdated-limit", "display which dependencies were outdated for more than X number of days", default: 20
+  end
+
+  begin
+    options.parse(ARGV).to_hash
+  rescue Slop::Error => e
+    puts e
+    puts options
+    exit
+  end
+end
+
+Dependabot.new.dependabot_time_to_merge(**get_options)

--- a/dependabot_time_to_merge.rb
+++ b/dependabot_time_to_merge.rb
@@ -1,83 +1,129 @@
-raise "You need to provide two dates in the following format: 2022-06-23" if ARGV.length != 2
-
 require "octokit"
 require "net/http"
 require "json"
 require "date"
 
-def client
-  @client ||=
-    Octokit::Client.new(
-      access_token: ENV.fetch("GITHUB_TOKEN"),
-      auto_paginate: false
-    )
-end
+PAGINATION_LIMIT = 10
+DAY_IN_SECONDS = 24 * 60 * 60
 
-def govuk_repos
-  @govuk_repos ||= 
-    JSON.parse(
-      Net::HTTP.get(
-        URI("https://docs.publishing.service.gov.uk/repos.json")
+class Dependabot
+  def client
+    @client ||=
+      Octokit::Client.new(
+        access_token: ENV.fetch("GITHUB_TOKEN"),
+        auto_paginate: false
       )
-    )
-      .map { |repo| "alphagov/#{repo["app_name"]}" }
-end
-
-def dependabot_prs
-  client.search_issues("is:pr user:alphagov is:closed author:app/dependabot archived:false", per_page: 100)
-  
-  last_response = client.last_response
-
-  return [] if last_response.data.items.empty?
-
-  pulls = []
-  sleep_time = 60 # GitHub's Search API applies strict secondary rate-limiting
-
-  # GitHub Search API has a limit of 1000 results,
-  # so we should only loop through 100-results-per-page 10 times.
-  # https://docs.github.com/en/rest/search#about-the-search-api
-  10.times do |i|
-    puts "Fetching next page of results... (API call ##{i+1})\nSleeping #{sleep_time} seconds to avoid rate-limiting..."
-    pulls << last_response.data.items
-    break if last_response.rels[:next].nil?
-    sleep sleep_time
-    last_response = last_response.rels[:next].get
   end
-  pulls.flatten
-end
 
-def govuk_prs
-  @govuk_prs ||=
-    dependabot_prs.flatten.select do |pr|
-      govuk_repos.any? { |repo| pr.repository_url.include?(repo) }
+  def govuk_repos
+    @govuk_repos ||=
+      JSON.parse(
+        Net::HTTP.get(
+          URI('https://docs.publishing.service.gov.uk/repos.json')
+        )
+      )
+          .map { |repo| "alphagov/#{repo['app_name']}" }
+  end
+
+  def get_dependency_name_and_version(title)
+    # Extract the dependency name and version from the PR title.
+    details = title.match(/^(?:(?:\[Security\]\ )?Bump|build\(deps.*\): bump) (.+) from (.+) to (.+)/) || title.match(/^Update (.+) requirement from (?:=|~>) (.+) to (?:=|~>)/)
+
+    # There are a few PRs that don't have the expected structure.
+    # We can ignore those since the number is low (for example, from 1040 PRs raised 33 have a different structure)
+    # and it won't have a big impact on the final results
+    return nil if details.nil?
+
+    [details[1], details[2]]
+  end
+
+  def get_repo_prs(repo)
+    repo_prs = []
+    (1..PAGINATION_LIMIT).each do |page|
+      repo_prs += client.list_issues(repo, { state: 'all', labels: 'dependencies', page: page })
     end
-end
+    repo_prs
+  rescue Octokit::NotFound
+    []
+  end
 
-def filter_by_date(from, to)
-  govuk_prs.flatten.select do |pr|
-    pr.pull_request["merged_at"].between?(Time.parse(from), Time.parse(to)) if pr.pull_request["merged_at"]
+  def dependabot_history_per_repo(repo)
+    repo_dependabot_prs = {}
+
+    get_repo_prs(repo).each do |pr|
+      dependency_name, from_version = get_dependency_name_and_version(pr.title)
+
+      next if dependency_name.nil?
+
+      repo_dependabot_prs[dependency_name] = [] if repo_dependabot_prs[dependency_name].nil?
+      repo_dependabot_prs[dependency_name] << {
+        created_at: pr.created_at,
+        merged_at: pr.pull_request['merged_at'],
+        closed_at: pr.closed_at,
+        from_version: from_version
+      }
+    end
+    repo_dependabot_prs
+  end
+
+  def get_repo_metrics(repo, from, to, outdated_limit)
+    # Get the insights for each repository
+    dependabot_prs = dependabot_history_per_repo(repo)
+
+    total_opened_prs = 0
+    time_to_merge = []
+    time_since_open = []
+
+    dependabot_prs.each do |dependency, prs|
+      opened_prs = prs.filter { |pr| pr[:created_at].between?(from, to) }
+
+      total_opened_prs += opened_prs.size
+
+      opened_prs.each do |opened_pr|
+        # Get the date when the earliest PR for bumping the current version was created
+        # In this way we include superseded PRs in our calculations
+        created_at = dependabot_prs[dependency]
+                     .filter { |pr| pr[:from_version] == opened_pr[:from_version] }
+                     .map { |pr| pr[:created_at] }.min
+
+        if opened_pr[:closed_at].nil?
+          days_since_open = (Time.now - created_at).to_i / DAY_IN_SECONDS
+          time_since_open << days_since_open
+          puts "Dependency #{ dependency } from #{ repo } has been outdated for #{ days_since_open } days" if days_since_open >= outdated_limit
+        end
+
+        next unless opened_pr[:merged_at]
+
+        days_to_merge = (opened_pr[:merged_at] - created_at).to_i / DAY_IN_SECONDS
+        time_to_merge << days_to_merge
+        puts "Dependency #{ dependency } from #{ repo } was merged in #{ days_to_merge } days" if days_to_merge >= outdated_limit
+      end
+    end
+
+    {
+      total_opened_prs: total_opened_prs,
+      time_since_open: time_since_open,
+      time_to_merge: time_to_merge
+    }
+  end
+
+  def dependabot_time_to_merge(from:, to:, outdated_limit:)
+    puts 'Fetching dependabot PRs...'
+    total_opened_prs = 0
+    time_to_merge = []
+    time_since_open = []
+
+    govuk_repos.each do |repo|
+      repo_metrics = get_repo_metrics(repo, Time.parse(from), Time.parse(to), outdated_limit)
+      total_opened_prs += repo_metrics[:total_opened_prs]
+      time_to_merge += repo_metrics[:time_to_merge]
+      time_since_open += repo_metrics[:time_since_open]
+    end
+
+    puts ""
+    puts "Between #{from} and #{to}:"
+    puts "- Dependabot raised #{total_opened_prs} PRs"
+    puts "- #{time_to_merge.size} were merged, within #{(time_to_merge.sum(0.0) / time_to_merge.size).round(2)} days on average, taking into account any superseded PRs."
+    puts "- #{time_since_open.size} are still open. They've been open for an average of #{(time_since_open.sum(0.0) / time_since_open.size).round(2)} days, taking into account any superseded PRs."
   end
 end
-
-def time_to_merge(from, to)
-  @time_to_merge = []
-  filter_by_date(from, to).each do |pr|
-    days_to_merge = (pr.pull_request["merged_at"] - pr.created_at).to_i / (24 * 60 * 60)
-    puts "Created at: #{pr.created_at}, merged at: #{pr.pull_request["merged_at"]}, time to merge: #{days_to_merge} days, url: #{pr.url}"
-    @time_to_merge << days_to_merge
-  end
-  print "Time to merge days array #{@time_to_merge}"
-  puts ""
-  puts "Total PRs #{@time_to_merge.size}"
-  puts "The time to merge was #{@time_to_merge.sum(0.0) / @time_to_merge.size} days on average"
-  puts "The median time to merge was #{median(@time_to_merge)} days"
-end
-
-def median(values_array)
-  return nil if values_array.empty?
-  sorted = values_array.sort
-  len = sorted.length
-  (sorted[(len - 1) / 2] + sorted[len / 2]) / 2.0
-end
-
-time_to_merge(ARGV[0], ARGV[1])

--- a/spec/dependabot_time_to_merge_spec.rb
+++ b/spec/dependabot_time_to_merge_spec.rb
@@ -1,0 +1,131 @@
+require 'rspec'
+require 'webmock/rspec'
+require_relative '../dependabot_time_to_merge'
+
+RSpec.describe '#dependabot_time_to_merge' do
+  let(:dependabot) do
+    Dependabot.new
+  end
+
+  let (:repo_name) { 'alphagov/test_api' }
+  let (:from) { Time.parse('2023-03-01 00:00:00') }
+  let (:to) { Time.parse('2023-03-16 00:00:00') }
+
+  let(:dependabot_prs) do
+    {
+      "foo": [
+        {
+          from_version: '1.0.0',
+          created_at: Time.parse('2023-03-07 00:00:00'),
+          closed_at: nil,
+          merged_at: nil
+        },
+        {
+          from_version: '1.0.0',
+          created_at: Time.parse('2023-03-01 00:00:00'),
+          closed_at: Time.parse('2023-03-07 00:00:00'),
+          merged_at: nil
+        },
+        {
+          from_version: '1.0.0',
+          created_at: Time.parse('2023-02-27 00:00:00'), # opened outside the timeframe, should not be counted
+          closed_at: Time.parse('2023-03-01 00:00:00'),
+          merged_at: nil
+        }
+      ],
+      "bar": [
+        {
+          from_version: '1.0.2',
+          created_at: Time.parse('2023-03-09 00:00:00'),
+          closed_at: nil,
+          merged_at: nil
+        },
+        {
+          from_version: '1.0.1',
+          created_at: Time.parse('2023-03-07 00:00:00'),
+          closed_at: Time.parse('2023-03-08 00:00:00'),
+          merged_at: Time.parse('2023-03-08 00:00:00')
+        },
+        {
+          from_version: '1.0.1',
+          created_at: Time.parse('2023-03-01 00:00:00'),
+          closed_at: Time.parse('2023-03-07 00:00:00'),
+          merged_at: nil
+        },
+        {
+          from_version: '1.0.1',
+          created_at: Time.parse('2023-02-26 00:00:00'), # opened outside the timeframe, should not be counted
+          closed_at: Time.parse('2023-03-01 00:00:00'),
+          merged_at: nil
+        }
+      ]
+    }
+  end
+
+  def stub_govuk_repos(repo_names)
+    stub_request(:get, 'https://docs.publishing.service.gov.uk/repos.json')
+      .to_return(
+        status: 200,
+        headers: { "Content-Type": 'application/json' },
+        body: repo_names.map { |repo_name| { "app_name": repo_name } }.to_json
+      )
+  end
+
+  def stub_govuk_dependabot_prs(repo_name, return_values)
+    stub_request(:get, "https://api.github.com/repos/#{repo_name}/issues?labels=dependencies&state=all")
+      .to_return(
+        status: 200,
+        headers: { "Content-Type": 'application/json' },
+        body: return_values.to_json
+      )
+  end
+
+  it 'gets dependency name and version' do
+    pr_titles = [
+      'Bump test from 2.2.0 to 2.2.1',
+      '[Security] Bump test from 2.2.0 to 2.2.1',
+      'build(deps): bump test from 2.2.0 to 2.2.1',
+      'build(deps-dev): bump test from 2.2.0 to 2.2.1',
+      'Update test requirement from = 2.2.0 to = 2.2.1',
+      'Update test requirement from ~> 2.2.0 to ~> 2.2.1'
+    ]
+
+    pr_titles.each do |title|
+      name, version = dependabot.get_dependency_name_and_version(title)
+
+      expect(name).to eq('test')
+      expect(version).to eq('2.2.0')
+    end
+  end
+
+  it 'returns noop name and version if title cannot be parsed' do
+    name, version = dependabot.get_dependency_name_and_version('Upgrade test')
+
+    expect(name).to eq(nil)
+    expect(version).to eq(nil)
+  end
+
+  it 'gets number of prs opened in a time frame' do
+    allow(dependabot).to receive(:dependabot_history_per_repo).with(repo_name).and_return(dependabot_prs)
+    allow(Time).to receive(:now).and_return(Time.parse('2023-03-10 00:00:00'))
+
+    results = dependabot.get_repo_metrics(repo_name, from, to, 20)
+    expect(results[:total_opened_prs]).to eq(5)
+  end
+
+  it 'gets the time since the prs are open including superseded prs' do
+    allow(dependabot).to receive(:dependabot_history_per_repo).with(repo_name).and_return(dependabot_prs)
+    allow(Time).to receive(:now).and_return(Time.parse('2023-03-10 00:00:00'))
+
+    results = dependabot.get_repo_metrics(repo_name, from, to, 20)
+    expect(results[:time_since_open]).to eq([11, 1])# how many days since the pr was open
+  end
+
+  it 'gets how long it took for the prs to be merged including superseded prs' do
+    allow(dependabot).to receive(:dependabot_history_per_repo).with(repo_name).and_return(dependabot_prs)
+    allow(Time).to receive(:now).and_return(Time.parse('2023-03-10 00:00:00'))
+
+    results = dependabot.get_repo_metrics(repo_name, from, to, 20)
+    expect(results[:time_to_merge]).to eq([10]) # how many days until the pr was merged
+  end
+end


### PR DESCRIPTION
At the moment we are ignoring any superseded Dependabot PRs in time-to-merge calculation. We want to have a more accurate metric on how long it takes until a dependency is upgraded to the latest version.

Before (between 2023-01-01 and 2023-02-06):
```
Total PRs 325
The time to merge was 1.48 days on average
```
After (between 2023-01-01 and 2023-02-06):
```
Fetching Dependabot PRs for each govuk repo...
Between 2023-01-01 and 2023-02-06:
- Dependabot raised 1067 PRs
- 875 were merged, within 3.19 days on average
- 18 are still open. They've been open for an average of 56.11 days, taking into account any superseded PRs.
```

Trello card: https://trello.com/c/OKiz0s7Q/3074-automate-measurement-of-time-dependency-was-out-of-date-ie-measure-time-to-merge-pr-inc-any-superseded-prs-3