### PR TITLE
Update apps script used for dependency checking

### DIFF
--- a/apps-script/Code.gs
+++ b/apps-script/Code.gs
@@ -18,7 +18,6 @@ function updateRepos(){
   var sheet = SpreadsheetApp.getActive().getSheetByName('Repos');
   sheet.clear({ contentsOnly: true });
   sheet.getRange(1, 1, csvData.length, csvData[0].length).setValues(csvData);
-  sheet.deleteColumns(3, (csvData[0].length - 2));
   updateSheet_(sheet);
 }
 

--- a/apps-script/Code.gs
+++ b/apps-script/Code.gs
@@ -2,6 +2,12 @@
  * @OnlyCurrentDoc
  */
 
+/*Formulas for conditional formatting of Repos tab
+
+Green: =ISNUMBER(MATCH(C2,INDEX(INDIRECT("'Tracking and reference'!$B$2:$G$10"),MATCH(C$1,INDIRECT("'Tracking and reference'!$A$2:$A$10"),0)),0))
+Red: =NOT(ISNUMBER(MATCH(C2,INDEX(INDIRECT("'Tracking and reference'!$B$2:$G$10"),MATCH(C$1,INDIRECT("'Tracking and reference'!$A$2:$A$10"),0)),0)))
+*/
+
 function onOpen() {
   var spreadsheet = SpreadsheetApp.getActive();
   var menuItems = [

--- a/apps-script/Code.gs
+++ b/apps-script/Code.gs
@@ -70,7 +70,7 @@ function updateRubyVersion_(repo, targetCell) {
   if (version) {
     targetCell.setValue(version);
   } else {
-    targetCell.setValue("unspecified");
+    targetCell.setValue("n/a");
   }    
 }
 


### PR DESCRIPTION
This makes a few changes to the Apps Script for the dependency checker spreadsheet:

- Stop deleting columns before importing new data (deleting the columns was tidier but meant we lost conditional formatting and cell references)
- Change "unspecified" to "n/a" to make it clearer
- Add the formulas used in conditional formatting, really just for safekeeping in case they get lost from the sheet
