### PR TITLE
Use new release workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -10,13 +10,16 @@ on:
         required: true
         type: string
         default: 'main'
+  release:
+    types: [released]
 
 jobs:
   build-and-publish-image:
+    if: github.event_name == 'workflow_dispatch' || startsWith(github.ref_name, 'v')
     name: Build and publish image
     uses: alphagov/govuk-infrastructure/.github/workflows/build-and-push-image.yml@main
     with:
-      gitRef: ${{ inputs.gitRef || github.ref }}
+      gitRef: ${{ inputs.gitRef || github.ref_name }}
     permissions:
       id-token: write
       contents: read

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,16 @@
+name: Release
+
+on:
+  workflow_dispatch:
+  workflow_run:
+    workflows: [CI]
+    types: [completed]
+    branches: [main]
+
+jobs:
+  release:
+    if: github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success'
+    name: Release
+    uses: alphagov/govuk-infrastructure/.github/workflows/release.yml@main
+    secrets:
+      GH_TOKEN: ${{ secrets.GOVUK_CI_GITHUB_API_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+# Ignore bundler config
+/.bundle


### PR DESCRIPTION
Description:
- New release  workflow that creates a new GitHub Release (and git tag) with an incremental version number. This version tag is then used to tag images and referenced in the rest of the deployment system.
- Adds a .gitignore file
- Based off https://github.com/alphagov/frontend/pull/3722
- Closes https://github.com/alphagov/govuk-dependency-checker/issues/41