### PR TITLE
Remove automatic triggering of deploy step

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -10,12 +10,9 @@ on:
         required: true
         type: string
         default: 'main'
-  release:
-    types: [released]
 
 jobs:
   build-and-publish-image:
-    if: github.event_name == 'workflow_dispatch' || startsWith(github.ref_name, 'v')
     name: Build and publish image
     uses: alphagov/govuk-infrastructure/.github/workflows/build-and-push-image.yml@main
     with:

--- a/README.md
+++ b/README.md
@@ -35,3 +35,8 @@ They all require `GITHUB_TOKEN` as an environment variable, with at
 least `repo` scope.
 
 There is also an Apps Script to pull dependency versions into a spreadsheet.
+
+## How to deploy
+
+This needs manual deployment to production. Once the `release` GitHub Action has run select the `deploy` GitHub action and
+ under `Use workflow from` choose to deploy from the latest tag. Then enter the latest tag number into the text field.


### PR DESCRIPTION
Description:
- Since the `govuk-ci` user isn't a member of the `gov-uk-production-deploy` GitHub group it can't deploy to the production environment
- Hence this still needs to be deployed manually by a member of the team so only trigger the workflow manually not when a new release is made
- Closes https://github.com/alphagov/govuk-dependency-checker/issues/41